### PR TITLE
Add/settings

### DIFF
--- a/src/main/java/com/segment/analytics/android/integrations/taplytics/TaplyticsIntegration.java
+++ b/src/main/java/com/segment/analytics/android/integrations/taplytics/TaplyticsIntegration.java
@@ -21,6 +21,7 @@ public class TaplyticsIntegration extends Integration<Taplytics> {
     };
     private static final String TAPLYTICS_KEY = "Taplytics";
     final Logger logger;
+    String apiKey;
     boolean liveUpdate;
 
     TaplyticsIntegration(Analytics analytics, ValueMap settings){

--- a/src/main/java/com/segment/analytics/android/integrations/taplytics/TaplyticsIntegration.java
+++ b/src/main/java/com/segment/analytics/android/integrations/taplytics/TaplyticsIntegration.java
@@ -3,6 +3,7 @@ package com.segment.analytics.android.integrations.taplytics;
 import com.segment.analytics.Analytics;
 import com.segment.analytics.ValueMap;
 import com.segment.analytics.integrations.Integration;
+import com.segment.analytics.integrations.Logger;
 import com.taplytics.sdk.Taplytics;
 
 /**
@@ -19,5 +20,16 @@ public class TaplyticsIntegration extends Integration<Taplytics> {
         }
     };
     private static final String TAPLYTICS_KEY = "Taplytics";
-    public TaplyticsIntegration(Analytics analytics, ValueMap settings){}
+    final Logger logger;
+    boolean liveUpdate;
+
+    TaplyticsIntegration(Analytics analytics, ValueMap settings){
+      logger = analytics.logger(TAPLYTICS_KEY);
+
+      String apiKey = settings.getString("apiKey");
+      boolean liveUpdate = settings.getBoolean("liveUpdate", true);
+
+      Taplytics.startTaplytics(analytics.getApplication(), apiKey);
+      logger.verbose("Taplytics.startTaplytics - (%s)", apiKey);
+    }
 };

--- a/src/main/java/com/segment/analytics/android/integrations/taplytics/TaplyticsIntegration.java
+++ b/src/main/java/com/segment/analytics/android/integrations/taplytics/TaplyticsIntegration.java
@@ -23,12 +23,14 @@ public class TaplyticsIntegration extends Integration<Taplytics> {
     final Logger logger;
     String apiKey;
     boolean liveUpdate;
+    int sessionMinutes;
 
     TaplyticsIntegration(Analytics analytics, ValueMap settings){
       logger = analytics.logger(TAPLYTICS_KEY);
 
       String apiKey = settings.getString("apiKey");
       liveUpdate = settings.getBoolean("liveUpdate", true);
+      sessionMinutes = settings.getInt("sessionMinutes", 10);
 
       Taplytics.startTaplytics(analytics.getApplication(), apiKey);
       logger.verbose("Taplytics.startTaplytics(analytics.getApplication(), %s)", apiKey);

--- a/src/main/java/com/segment/analytics/android/integrations/taplytics/TaplyticsIntegration.java
+++ b/src/main/java/com/segment/analytics/android/integrations/taplytics/TaplyticsIntegration.java
@@ -28,9 +28,9 @@ public class TaplyticsIntegration extends Integration<Taplytics> {
       logger = analytics.logger(TAPLYTICS_KEY);
 
       String apiKey = settings.getString("apiKey");
-      boolean liveUpdate = settings.getBoolean("liveUpdate", true);
+      liveUpdate = settings.getBoolean("liveUpdate", true);
 
       Taplytics.startTaplytics(analytics.getApplication(), apiKey);
-      logger.verbose("Taplytics.startTaplytics - (%s)", apiKey);
+      logger.verbose("Taplytics.startTaplytics(analytics.getApplication(), %s)", apiKey);
     }
 };

--- a/src/test/java/com/segment/analytics/android/integrations/taplytics/TaplyticsTest.java
+++ b/src/test/java/com/segment/analytics/android/integrations/taplytics/TaplyticsTest.java
@@ -1,26 +1,11 @@
 package com.segment.analytics.android.integrations.taplytics;
 
-import android.app.Activity;
 import android.app.Application;
-import android.os.Bundle;
 import com.segment.analytics.Analytics;
-import com.segment.analytics.Properties;
-import com.segment.analytics.Traits;
 import com.segment.analytics.ValueMap;
-import com.segment.analytics.android.integrations.taplytics.BuildConfig;
 import com.segment.analytics.integrations.Logger;
-import com.segment.analytics.test.AliasPayloadBuilder;
-import com.segment.analytics.test.IdentifyPayloadBuilder;
-import com.segment.analytics.test.ScreenPayloadBuilder;
-import com.segment.analytics.test.TrackPayloadBuilder;
 import com.taplytics.sdk.Taplytics;
 
-import java.util.Arrays;
-import java.util.Collections;
-import org.hamcrest.Description;
-import org.hamcrest.TypeSafeMatcher;
-import org.json.JSONException;
-import org.json.JSONObject;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -35,14 +20,11 @@ import org.robolectric.annotation.Config;
 import static com.segment.analytics.Utils.createTraits;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.argThat;
 import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.MockitoAnnotations.initMocks;
 import static org.powermock.api.mockito.PowerMockito.mock;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
-import static org.powermock.api.mockito.PowerMockito.verifyNoMoreInteractions;
 import static org.powermock.api.mockito.PowerMockito.verifyStatic;
 import static org.powermock.api.mockito.PowerMockito.when;
 
@@ -59,31 +41,34 @@ public class TaplyticsTest {
     Logger logger;
     @Mock
     Analytics analytics;
-
     TaplyticsIntegration integration;
+    Taplytics taplytics;
 
     @Before
     public void setUp() {
         initMocks(this);
         mockStatic(Taplytics.class);
-        logger = Logger.with(Analytics.LogLevel.DEBUG);
-        when(analytics.logger("Taplytics")).thenReturn(logger);
         when(analytics.getApplication()).thenReturn(context);
+        when(analytics.logger("Taplytics")).thenReturn(logger);
 
-
-        integration = new TaplyticsIntegration(analytics, new ValueMap());
+        integration = new TaplyticsIntegration(analytics, new ValueMap().putValue("apiKey", "foo"));
+        mockStatic(Taplytics.class);
     }
 
     @Test
     public void factory() {
-        ValueMap settings = new ValueMap().putValue("token", "foo");
+        ValueMap settings = new ValueMap() //
+            .putValue("apiKey", "foo")
+            .putValue("liveUpdate", true);
 
         TaplyticsIntegration integration =
                 (TaplyticsIntegration) TaplyticsIntegration.FACTORY.create(settings, analytics);
 
         verifyStatic();
         //Integration initialized
+        Taplytics.startTaplytics(context, "foo");
+        verifyStatic();
         //Make sure settings are set correctly
-        Taplytics.startTaplytics(context, "YOUR TAPLYTICS API KEY");
+        assertThat(integration.liveUpdate).isTrue();
     }
 }

--- a/src/test/java/com/segment/analytics/android/integrations/taplytics/TaplyticsTest.java
+++ b/src/test/java/com/segment/analytics/android/integrations/taplytics/TaplyticsTest.java
@@ -34,7 +34,7 @@ import static org.powermock.api.mockito.PowerMockito.when;
 @PrepareForTest(Taplytics.class)
 public class TaplyticsTest {
 
-    @Rule
+  @Rule
     public PowerMockRule rule = new PowerMockRule();
     @Mock
     Application context;
@@ -48,11 +48,11 @@ public class TaplyticsTest {
     public void setUp() {
         initMocks(this);
         mockStatic(Taplytics.class);
-        when(analytics.getApplication()).thenReturn(context);
+        logger = Logger.with(Analytics.LogLevel.DEBUG);
         when(analytics.logger("Taplytics")).thenReturn(logger);
+      when(analytics.getApplication()).thenReturn(context);
 
         integration = new TaplyticsIntegration(analytics, new ValueMap().putValue("apiKey", "foo"));
-        mockStatic(Taplytics.class);
     }
 
     @Test
@@ -66,8 +66,6 @@ public class TaplyticsTest {
 
         verifyStatic();
         //Integration initialized
-        Taplytics.startTaplytics(context, "foo");
-        verifyStatic();
         //Make sure settings are set correctly
         assertThat(integration.liveUpdate).isTrue();
     }

--- a/src/test/java/com/segment/analytics/android/integrations/taplytics/TaplyticsTest.java
+++ b/src/test/java/com/segment/analytics/android/integrations/taplytics/TaplyticsTest.java
@@ -59,7 +59,8 @@ public class TaplyticsTest {
     public void factory() {
         ValueMap settings = new ValueMap() //
             .putValue("apiKey", "foo")
-            .putValue("liveUpdate", true);
+            .putValue("liveUpdate", true)
+            .putValue("sessionMinutes", 20);
 
         TaplyticsIntegration integration =
                 (TaplyticsIntegration) TaplyticsIntegration.FACTORY.create(settings, analytics);
@@ -68,5 +69,6 @@ public class TaplyticsTest {
         //Integration initialized
         //Make sure settings are set correctly
         assertThat(integration.liveUpdate).isTrue();
+        assertThat(integration.sessionMinutes).isEqualTo(20);
     }
 }


### PR DESCRIPTION
This adds the basic Taplytics Settings that will be the MVP for this integration.

This includes `liveUpdate` and `sessionMinutes` which are the settings that affect how data is collected. The other two `shakeMenu` and `turnMenu` are development tools that will be added when customers ask for them.
![image](https://cloud.githubusercontent.com/assets/5373129/14690012/d3a91206-06fe-11e6-8bd7-c70400032ba5.png)

[The documentation for these is here](https://github.com/taplytics/Taplytics-Android-SDK/blob/master/START.md#2-initialization)
